### PR TITLE
Fix initial only types not evaluated as inital types

### DIFF
--- a/src/Config/FilterConfig.php
+++ b/src/Config/FilterConfig.php
@@ -14,6 +14,7 @@ use Contao\Environment;
 use Contao\InsertTags;
 use Doctrine\DBAL\Connection;
 use HeimrichHannot\FilterBundle\Filter\AbstractType;
+use HeimrichHannot\FilterBundle\Filter\Type\PublishedType;
 use HeimrichHannot\FilterBundle\Filter\Type\SqlType;
 use HeimrichHannot\FilterBundle\Form\Extension\FormButtonExtension;
 use HeimrichHannot\FilterBundle\Form\Extension\FormTypeExtension;
@@ -228,7 +229,7 @@ class FilterConfig implements \JsonSerializable
                 return;
             }
 
-            $initial = ((bool) $element->isInitial || SqlType::TYPE === $element->type);
+            $initial = ((bool) $element->isInitial || \in_array($element->type, [SqlType::TYPE, PublishedType::TYPE]));
 
             if (!isset($types[$element->type])
                 || \in_array($element->id, $skipElements)

--- a/src/Config/FilterConfig.php
+++ b/src/Config/FilterConfig.php
@@ -14,6 +14,7 @@ use Contao\Environment;
 use Contao\InsertTags;
 use Doctrine\DBAL\Connection;
 use HeimrichHannot\FilterBundle\Filter\AbstractType;
+use HeimrichHannot\FilterBundle\Filter\Type\SqlType;
 use HeimrichHannot\FilterBundle\Form\Extension\FormButtonExtension;
 use HeimrichHannot\FilterBundle\Form\Extension\FormTypeExtension;
 use HeimrichHannot\FilterBundle\Form\FilterType;
@@ -227,9 +228,12 @@ class FilterConfig implements \JsonSerializable
                 return;
             }
 
-            if (!isset($types[$element->type]) || \in_array($element->id, $skipElements) ||
-                $mode === static::QUERY_BUILDER_MODE_INITIAL_ONLY && !$element->isInitial ||
-                $mode === static::QUERY_BUILDER_MODE_SKIP_INITIAL && $element->isInitial) {
+            $initial = ((bool) $element->isInitial || SqlType::TYPE === $element->type);
+
+            if (!isset($types[$element->type])
+                || \in_array($element->id, $skipElements)
+                || $mode === static::QUERY_BUILDER_MODE_INITIAL_ONLY && !$initial
+                || $mode === static::QUERY_BUILDER_MODE_SKIP_INITIAL && $initial) {
                 continue;
             }
 

--- a/src/Config/FilterConfig.php
+++ b/src/Config/FilterConfig.php
@@ -15,6 +15,7 @@ use Contao\InsertTags;
 use Doctrine\DBAL\Connection;
 use HeimrichHannot\FilterBundle\Filter\AbstractType;
 use HeimrichHannot\FilterBundle\Filter\Type\PublishedType;
+use HeimrichHannot\FilterBundle\Filter\Type\SkipParentsType;
 use HeimrichHannot\FilterBundle\Filter\Type\SqlType;
 use HeimrichHannot\FilterBundle\Form\Extension\FormButtonExtension;
 use HeimrichHannot\FilterBundle\Form\Extension\FormTypeExtension;
@@ -229,7 +230,11 @@ class FilterConfig implements \JsonSerializable
                 return;
             }
 
-            $initial = ((bool) $element->isInitial || \in_array($element->type, [SqlType::TYPE, PublishedType::TYPE]));
+            $initial = ((bool) $element->isInitial || \in_array($element->type, [
+                    PublishedType::TYPE,
+                    SqlType::TYPE,
+                    SkipParentsType::TYPE,
+                ]));
 
             if (!isset($types[$element->type])
                 || \in_array($element->id, $skipElements)


### PR DESCRIPTION
This PR fixes the issue that some types, that have no "non-intial option" are not evaluated as initial type. 

This covers followig types:
- sql
- published