### PR TITLE
Move hide label option into method

### DIFF
--- a/src/Filter/AbstractType.php
+++ b/src/Filter/AbstractType.php
@@ -220,7 +220,7 @@ abstract class AbstractType
         $options['label'] = $this->getLabel($element, $builder) ?: $element->title;
 
         // sr-only style for non-bootstrap projects is shipped within the filter_form_* templates
-        if (true === (bool) $element->hideLabel) {
+        if ($this->getHideLabel($element)) {
             $options['label_attr'] = ['class' => 'sr-only'];
         }
 
@@ -272,6 +272,11 @@ abstract class AbstractType
         }
 
         return $options;
+    }
+
+    public function getHideLabel(FilterConfigElementModel $element): bool
+    {
+        return (bool) $element->hideLabel;
     }
 
     /**

--- a/src/Filter/Type/ButtonType.php
+++ b/src/Filter/Type/ButtonType.php
@@ -60,4 +60,9 @@ class ButtonType extends AbstractType
 
         return $label;
     }
+
+    public function getHideLabel(FilterConfigElementModel $element): bool
+    {
+        return false;
+    }
 }

--- a/src/Filter/Type/ResetType.php
+++ b/src/Filter/Type/ResetType.php
@@ -54,4 +54,9 @@ class ResetType extends AbstractType
     public function getDefaultOperator(FilterConfigElementModel $element)
     {
     }
+
+    public function getHideLabel(FilterConfigElementModel $element): bool
+    {
+        return false;
+    }
 }

--- a/src/Filter/Type/SubmitType.php
+++ b/src/Filter/Type/SubmitType.php
@@ -46,4 +46,9 @@ class SubmitType extends AbstractType
     public function getDefaultOperator(FilterConfigElementModel $element)
     {
     }
+
+    public function getHideLabel(FilterConfigElementModel $element): bool
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
This PR moved the evaluation of the hide label option into an override able  method and uses this change in ResetType, SubmitType and ButtonType to fix problems with old db entries.