### PR TITLE
fix invalid data types lead to outdated values

### DIFF
--- a/src/Config/FilterConfig.php
+++ b/src/Config/FilterConfig.php
@@ -306,6 +306,7 @@ class FilterConfig implements \JsonSerializable
 
             // do not save filter id in session
             $this->setData($this->filter['mergeData'] ? array_merge($this->getData(), $data) : $data);
+            $this->getBuilder()->setData($this->getData());
 
             // allow reset, support different form configuration with same form name
             if ($this->isResetButtonClicked($form)) {


### PR DESCRIPTION
If mapping the values to the forms fails in 1, the form values are not updated. This line refresh the values in the builder.

1: https://github.com/heimrichhannot/contao-filter-bundle/blob/81f1bdecfd30e6023abf35a911930f46d4fb5efb/src/Config/FilterConfig.php#L654