### PR TITLE
add concat search on child table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.28.X] - 2023-12-XX
+- Added: child table concat search
+
 ## [1.27.2] - 2023-12-11
 - Fixed: filter sorting options not working
 

--- a/src/DataContainer/FilterConfigElementContainer.php
+++ b/src/DataContainer/FilterConfigElementContainer.php
@@ -26,11 +26,11 @@ class FilterConfigElementContainer
     public const PALETTE_PREFIX = '{general_legend},title,type,isInitial;';
     public const PALETTE_SUFFIX = '{publish_legend},published;';
 
-    private Utils               $utils;
-    private FilterCollection    $filterCollection;
+    private Utils $utils;
+    private FilterCollection $filterCollection;
     private TranslatorInterface $translator;
-    private RequestStack        $requestStack;
-    private FilterManager       $filterManager;
+    private RequestStack $requestStack;
+    private FilterManager $filterManager;
 
     public function __construct(Utils $utils, FilterCollection $filterCollection, TranslatorInterface $translator, RequestStack $requestStack, FilterManager $filterManager)
     {
@@ -86,8 +86,8 @@ class FilterConfigElementContainer
         $enabled = $class::isEnabledForCurrentContext($context);
 
         return '<div class="tl_content_left">'
-            .($enabled ? '' : Image::getHtml('error.svg', '', 'style="padding-right: 3px;" title="'.$this->translator->trans('huh.filter.warning.not_supported_in_current_content').'"'))
-            .($row['title'] ?: $row['id']).' <span style="color:#b3b3b3; padding-left:3px">['.($GLOBALS['TL_LANG']['tl_filter_config_element']['reference']['type'][$row['type']] ?: $row['type']).($row['isInitial'] ? ' – Initial' : '').']</span></div>';
+            . ($enabled ? '' : Image::getHtml('error.svg', '', 'style="padding-right: 3px;" title="' . $this->translator->trans('huh.filter.warning.not_supported_in_current_content') . '"'))
+            . ($row['title'] ?: $row['id']) . ' <span style="color:#b3b3b3; padding-left:3px">[' . ($GLOBALS['TL_LANG']['tl_filter_config_element']['reference']['type'][$row['type']] ?: $row['type']) . ($row['isInitial'] ? ' – Initial' : '') . ']</span></div>';
     }
 
     /**
@@ -133,7 +133,63 @@ class FilterConfigElementContainer
         $options = [];
 
         foreach ($fields as $field => $label) {
-            $options[$field] = $field.' <span style="display: inline; color:#999; padding-left:3px">['.$label.']</span>';
+            $options[$field] = $field . ' <span style="display: inline; color:#999; padding-left:3px">[' . $label . ']</span>';
+        }
+
+        return $options;
+    }
+
+    /**
+     * Support 1 child table atm
+     * @Callback(table="tl_filter_config_element", target="fields.childTable.options")
+     */
+    public function onChildTableOptionsCallback(DataContainer $dc = null): array
+    {
+        if (null === ($model = $this->utils->model()->findModelInstanceByPk($dc->table, $dc->id))) {
+            return [];
+        }
+
+        if (null === ($filterConfig = $this->filterManager->findById($model->pid))) {
+            return [];
+        }
+
+        $options = [];
+        $childTables = $GLOBALS['TL_DCA'][$filterConfig->getFilter()['dataContainer']]['config']['ctable'] ?? [];
+
+        foreach ($childTables as $childTable) {
+            $options[$childTable] = $childTable;
+        }
+
+        return $options;
+    }
+
+    /**
+     * @Callback(table="tl_filter_config_element", target="fields.childFields.options")
+     */
+    public function onChildFieldOptionsCallback(DataContainer $dc = null): array
+    {
+        if (null === ($model = $this->utils->model()->findModelInstanceByPk($dc->table, $dc->id))) {
+            return [];
+        }
+
+        if(!$model->childTable) {
+            return [];
+        }
+
+        if (null === ($filterConfig = $this->filterManager->findById($model->pid))) {
+            return [];
+        }
+
+
+        $fields = $this->utils->dca()->getDcaFields($model->childTable, [
+            'onlyDatabaseFields' => true,
+            'localizeLabels' => true,
+        ]);
+
+        $options = [];
+
+        foreach ($fields as $field => $label) {
+            $options[$field] = $field . ' <span style="display: inline; color:#999; padding-left:3px">[' . $label . ']</span>';
         }
 
         return $options;

--- a/src/Resources/contao/dca/tl_filter_config_element.php
+++ b/src/Resources/contao/dca/tl_filter_config_element.php
@@ -121,10 +121,11 @@ $GLOBALS['TL_DCA']['tl_filter_config_element'] = [
             'allowHtmlGeoLocation',
             'submitOnInput',
             'addMultilingualInitialValues',
+            'addChildFields',
         ],
         'default' => '{general_legend},title,type,isInitial;{publish_legend},published;',
         'text' => '{general_legend},title,type,isInitial;{config_legend},field,customName,customOperator,addDefaultValue,submitOnInput;{visualization_legend},addPlaceholder,customLabel,hideLabel,inputGroup;{expert_legend},cssClass;{publish_legend},published;',
-        \HeimrichHannot\FilterBundle\Filter\Type\TextConcatType::TYPE => '{general_legend},title,type,isInitial;{config_legend},fields,name,submitOnInput;{visualization_legend},addPlaceholder,customLabel,hideLabel,inputGroup;{expert_legend},cssClass;{publish_legend},published;',
+        \HeimrichHannot\FilterBundle\Filter\Type\TextConcatType::TYPE => '{general_legend},title,type,isInitial;{config_legend},fields,name,submitOnInput,addChildFields;{visualization_legend},addPlaceholder,customLabel,hideLabel,inputGroup;{expert_legend},cssClass;{publish_legend},published;',
         'textarea' => '{general_legend},title,type,isInitial;{config_legend},field,customName,customOperator,addDefaultValue;{visualization_legend},addPlaceholder,customLabel,hideLabel,inputGroup;{expert_legend},cssClass;{publish_legend},published;',
         \HeimrichHannot\FilterBundle\Filter\Type\EmailType::TYPE => '{general_legend},title,type,isInitial;{config_legend},field,customName,customOperator,addDefaultValue;{visualization_legend},addPlaceholder,customLabel,hideLabel,inputGroup;{expert_legend},cssClass;{publish_legend},published;',
         \HeimrichHannot\FilterBundle\Filter\Type\IntegerType::TYPE => '{general_legend},title,type,isInitial;{config_legend},field,customName,customOperator,addDefaultValue,grouping,scale,rounding_mode;{visualization_legend},addPlaceholder,customLabel,hideLabel,inputGroup;{expert_legend},cssClass;{publish_legend},published;',
@@ -196,6 +197,7 @@ $GLOBALS['TL_DCA']['tl_filter_config_element'] = [
         'published' => 'start,stop',
         'submitOnInput' => 'threshold,debounce',
         'addMultilingualInitialValues' => 'multilingualInitialValues',
+        'addChildFields' => 'childTable, childFields',
     ],
     'fields' => [
         'id' => [
@@ -265,6 +267,32 @@ $GLOBALS['TL_DCA']['tl_filter_config_element'] = [
             'filter' => true,
             'inputType' => 'checkboxWizard',
             'eval' => ['chosen' => true, 'includeBlankOption' => true, 'multiple' => true, 'mandatory' => true],
+            'sql' => 'blob NULL',
+        ],
+        'addChildFields' => [
+            'exclude' => true,
+            'inputType' => 'checkbox',
+            'eval' => ['tl_class' => 'w50', 'submitOnChange' => true],
+            'sql' => "char(1) NOT NULL default ''",
+        ],
+        'childTable' => [
+            'exclude' => true,
+            'filter' => true,
+            'inputType' => 'select',
+            'eval' => [
+                'chosen' => true,
+                'tl_class' => 'w100',
+                'submitOnChange' => true,
+                'mandatory' => true,
+                'includeBlankOption' => true,
+            ],
+            'sql' => "varchar(128) NOT NULL default ''",
+        ],
+        'childFields' => [
+            'exclude' => true,
+            'filter' => true,
+            'inputType' => 'checkboxWizard',
+            'eval' => ['chosen' => true, 'includeBlankOption' => true, 'multiple' => true],
             'sql' => 'blob NULL',
         ],
         'parentField' => [

--- a/src/Resources/contao/languages/de/tl_filter_config_element.php
+++ b/src/Resources/contao/languages/de/tl_filter_config_element.php
@@ -126,6 +126,9 @@ $lang['multilingualInitialValues'] = ['Sprachenabhängige initiale Werte', 'Setz
 $lang['language'] = ['Sprache', 'Wählen Sie hier eine Sprache aus.'];
 $lang['cf_newsCategories'] = ['Kategorien', 'Wählen Sie hier die Kategorien aus, welche gefiltert werden sollen.'];
 $lang['cf_newsCategoriesChilds'] = ['Kind-Kategorien anzeigen', 'Wählen Sie diese Option, wenn anstelle der ausgewählten Kategorien deren Kind-Kategorien ausgegeben werden sollen. Enthält eine Kategorie keine Kind-Kategorien, dann wird diese weiterhin ausgegeben.'];
+$lang['addChildFields'] = ['Kindfelder aktivieren', 'Wählen Sie diese Option, wenn die Suche in der Kindtabelle auch stattfinden soll.'];
+$lang['childTable'] = ['Kindtabelle auswählen', 'Wählen Sie eine Kindtabelle aus, um die dazugehörigen Felder anzuzeigen.'];
+$lang['childFields'] = ['Kindfelder', 'Wählen Sie hier mehrere Felder aus, die in der gewählten Reihenfolge verknüpft werden sollen.'];
 
 // sort
 $lang['sortOptions'] = ['Sortier-Optionen', 'Fügen Sie hier die gewünschten Sortieroptionen hinzu.'];


### PR DESCRIPTION
Expand filter element TextConcatType with concat text search on child table.

There is a new child table and fields selection in filter config on concat type.

Test steps:

1. Launch an existing project with concat search filter used (BEG, /pressemitteilungen)
2. Swap the contao-filter-bundle with this branch
3. Search for keyword that only included (optimal) in child contents (eg. 'bayerwald')
Expected:
Some results are shown
Before:
No results