### PR TITLE
remove heimrichhannot/truncate-html

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     "heimrichhannot/contao-multi-column-editor-bundle": "^2.0",
     "heimrichhannot/contao-utils-bundle": "^2.226",
     "heimrichhannot/contao-twig-support-bundle": "^0.2.16||^1.0",
-    "heimrichhannot/truncate-html": "^2.0",
     "symfony/config": "^4.4||^5.4",
     "symfony/dependency-injection": "^4.4||^5.4",
     "symfony/event-dispatcher-contracts": "^1.0 || ^2.0 || ^3.0",

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -139,16 +139,6 @@ services:
     autowire: true
   HeimrichHannot\FilterBundle\Util\FilterAjaxUtil: '@huh.filter.util.filter_ajax'
 
-  twig.truncate.service:
-    class: Urodoz\Truncate\TruncateService
-
-  twig.extension.truncate.html:
-    class: Urodoz\Truncate\Bridge\Twig\TruncateExtension
-    arguments:
-    - "@twig.truncate.service"
-    tags:
-    - { name: twig.extension }
-
   twig.extension.string:
     class: Twig\Extra\String\StringExtension
     autowire: true


### PR DESCRIPTION
The dependency [heimrichhannot/truncate-html](https://packagist.org/packages/heimrichhannot/truncate-html) is ubiquitous and also abandoned.

The truncate services in services.yml were redeclared nonsensically, meaning copy-pasted from the truncate-html extension. The twig filter `truncateHtml` provided by that extension isn't used anywhere in the templates.

If contao-filter-bundle is installed alongside or as a dependency of other extensions that rely on the inherited dependency, these should declare it as a dependency on their own either way.

Therefore, it is save to remove heimrichhannot/truncate-html from the dependencies of this bundle.